### PR TITLE
Name Changes, Minor fixes and Blog Migrate

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -18,3 +18,8 @@ Cornelius Fiddlebone:
   name        : Cornelius Fiddlebone
   bio         : "I ordered what?"
   avatar      : "/assets/images/bio-photo.jpg"
+
+Suchetan R S:
+  nick        : Suché
+  name        : Suchetan R S
+  bio         : "I solved a 3x3 under quarter of a minute"

--- a/_posts/2017/2017-06-03-Why-Science.md
+++ b/_posts/2017/2017-06-03-Why-Science.md
@@ -3,16 +3,14 @@ layout: post
 author: Hareesh Nair
 title: Why Science?
 tags: Observations
-category: "Uncategorized"
+category: Uncategorized
 type: Blog
 image: https://i.imgur.com/s8nBcTR.jpg
 ---
-\
-![Path](https://i.imgur.com/s8nBcTR.jpg)
 
 Humans are a tiny speck in this vast universe. We have always been curious and we have this intuitive evolutionary thirst to answer every question. This species having a more developed brain began to consider questioning what we see and feel as an important component to progress apart from food and mating.
 
-##### Hypothesis.
+##### Hypothesis
 
 One approach is to observe and make a hypothesis based on the boundations of known math and imagination. A person in the metal age observing sparks coming from a hammer striking on a metal piece could immediately draw an analogy  to the lightning strikes lighting up the sky. The hypothesis was simple and straight forward. There is a large hammer up there creating these sparks. That should be so logical. Now, let’s draw some conclusion from this hypothesis which is very likely correct. There must be some superhuman being who can handle such a big hammer. A super powered god who can create lightning upon his will with his super powered hammer. We don’t know his name but let’s call him Thor.
 
@@ -25,8 +23,6 @@ Let’s say people like this theory and they accept it because it is supposedly 
 People like this theory and they accept it. However, they are open to questioning and challenging their own model to test its credibility and reliability because questioning is what led them to establish their set of axioms. The process of questioning which always lets open a door to truth, which would make them realize their mistakes is what will take them ahead and is ultimately what will help them progress. It may slow down the progress of an existing set of ideas but it will never, on a large scale of time, be something which slowed them down. It is more like increasing the clarity and moving on a better direction at a slower pace than just going ahead without a realization of what you are and how terribly wrong your approach regarding understanding the universe could be. So, we stop and acknowledge both individuals who claim that lightning is because of clouds or cats and we go with the more logical option. The option which answers further questions efficiently. Let’s call this option B.
 
 Now why science? Because science is option B. The process that we follow to establish the foundation of science, we are ready to question it as well. Just the fact that you can question science and there will be an answer makes science credible. And if there is not an answer to the question, it’s even better, that’s when you change those pillars. That’s when you redefine science. That’s when you discover something new. A hidden face of this universe unveiling in front of you. Now, if someone says that times slows down in a moving frame, you cannot choose to refuse it. It’s not an opinion. It’s just how the world works. Doesn’t mean that you cannot question it. You can always question the reliability of the conclusions drawn from an experiment or how a hypothesis is unstable or stable. You always have the liberty to choose, to do, to manipulate, to find a better solution and whatever logically is right will be accepted.
-
-
 
 Towards a more philosophical aspect. If someone says the Earth is flat or vaccines are not good or cancer is a propaganda, we have two options. A or B? We can refuse them, refuse to acknowledge and ignore them. We can progress with what we believe is right. Follow the methodical system we follow to establish science which we personally chose as a right option. Or we can wait and consider conflicting contradicting opinions. Slow down science for a second and ensure are we on the right track? If no, go back and fix where we went wrong. If yes, provide a reasoning to why the system is still consistent and go ahead at the original pace we are meant to go.
 

--- a/_posts/2020-F/2020-04-12-Evolution-of-the-First-Galaxies.md
+++ b/_posts/2020-F/2020-04-12-Evolution-of-the-First-Galaxies.md
@@ -2,7 +2,7 @@
 layout: post
 author: Aeishna Khaund
 tags: Galaxies Lecture Matt-Malkan UCLA
-category: Messrier-Series
+category: Messier-Series
 type: Event
 image: "assets/posts/Celestia/SEDSLogoblack.png"
 ---

--- a/_posts/2020-F/2020-04-12-Evolution-of-the-First-Galaxies.md
+++ b/_posts/2020-F/2020-04-12-Evolution-of-the-First-Galaxies.md
@@ -1,9 +1,8 @@
 ---
 layout: post
-title:  "The Evolution of the First Galaxies"
 author: Aeishna Khaund
 tags: Galaxies Lecture Matt-Malkan UCLA
-category: Messier-Series
+category: Messrier-Series
 type: Event
 image: "assets/posts/Celestia/SEDSLogoblack.png"
 ---

--- a/_posts/2020-F/2020-06-20-Persieds-Meteor-Shower-2020.md
+++ b/_posts/2020-F/2020-06-20-Persieds-Meteor-Shower-2020.md
@@ -2,10 +2,12 @@
 layout: post
 author: Yashraj Patil
 tags: Perseids Meteors Skywatching
-category: "Uncategorized"
+category: Uncategorized
 type: Event
 image: "assets/posts/2020/PMS2020.png"
 ---
+
+![Perseids Meteor Shower](../assets/posts/2020/PMS2020.png)
 
 Since the beginning of mankind on our blue planet, as old as our time goes, we have looked with awe and marveled at those bright streaks of lights that whiz past the black canvas on a starry night. The meteor showers are extraordinary cosmic events that have had impacts on many generations of civilizations and shaped their beliefs to carve out beautiful pieces of myths and legends. Evolving from bad omens to good luck over centuries of rise and fall of cultures, today we look at them with a logical perspective to explain their interesting origins to their dooming fate.
 

--- a/_posts/2020-F/2020-07-06-A-Brief-Overview-of-R-P-Feynman's-Thesis.md
+++ b/_posts/2020-F/2020-07-06-A-Brief-Overview-of-R-P-Feynman's-Thesis.md
@@ -1,12 +1,13 @@
 ---
 layout: post
-title:  "A Brief Overview of R P Feynman’s Thesis"
 author: Bhuvan S V
-tags: RP_Feyman
-category: "Science"
+tags: Astrophysics Author:Bhuvan-S-V Physics RP-Feyman Science
+category: Science
 type: Blog
-image: ../assets/posts/2020/RPF2020.jpeg
+image: "assets/posts/2020/RPF2020.jpeg"
 ---
+
+![RPF2020](../assets/posts/2020/RPF2020.jpeg)
 
 ## Introduction
 
@@ -18,9 +19,9 @@ Richard Feynman is one of the most famous physicists of the 20th century, changi
 
 Consider a free charged particle accelerating in space. As any accelerated charge would, this particle would emit radiation, thereby losing energy (law of conservation of energy). This loss of energy is simply explained in case of a charged particle in a potential field; say an electron in an atom- the potential of the positively charged nucleus would do the work necessary to decrease the energy of the electron. But for a free charge, there is no such potential to do the needed work.
 
-![Imgur](https://i.imgur.com/1gNnE1cm.png)
+![Imgur](https://i.imgur.com/1gNnE1cm.png)  
 
-The then accepted explanation was that the charged particle would act on itself- the work is done due to “self-energy”. Feynman wished to remove this self-energy, by introducing another charge particle, which would act on the radiating particle. This can be possible when one sees that Maxwell’s equations allow for two solutions- one with positive time and other with negative time. The mechanism is as follows: the radiation from particle 1 would cause particle 2 to emit radiation back to particle 1, thereby affecting it. This seemingly violates principle of causality, but when you consider a large number of particles and both solutions of Maxwell’s equations, this is seen to actually obey it. Feynman calls this theory, which he developed along with his advisor John Archibald Wheeler, the theory of action at a distance (now called Wheeler-Feynman absorber theory). The main principles of this theory are as follows:
+The then accepted explanation was that the charged particle would act on itself- the work is done due to “self-energy”. Feynman wished to remove this self-energy, by introducing another charge particle, which would act on the radiating particle. This can be possible when one sees that Maxwell’s equations allow for two solutions- one with positive time and other with negative time. The mechanism is as follows: the radiation from particle 1 would cause particle 2 to emit radiation back to particle 1, thereby affecting it. This seemingly violates principle of causality, but when you consider a large number of particles and both solutions of Maxwell’s equations, this is seen to actually obey it. Feynman calls this theory, which he developed along with his advisor John Archibald Wheeler, the theory of action at a distance (now called Wheeler-Feynman absorber theory). The main principles of this theory are as follows:  
 
 1. Acceleration of a charged particle is due to its sum interactions with other charged particles, or, there is no “self-energy”. This also means that a free particle alone cannot spontaneously emit radiation.
 
@@ -30,7 +31,7 @@ The then accepted explanation was that the charged particle would act on itself-
 
 Since this theory is difficult to represent in Hamiltonian formulation (it isn’t possible to express as harmonic oscillators, as there are other interactions as well), we use the principle of least action from classical mechanics to find the equations of motion. We also note that the Wheeler-Feynman theory is now considered to be not true.
 
-### I. Least action in classical mechanics:
+### I. Least action in classical mechanics
 
 The first part of the thesis deals with the principle of least action in classical mechanics. To go further we need to be familiar with some terms and results that shall be used throughout the thesis:
 

--- a/_posts/2020-F/2020-10-12-M104-Sombrero-Galaxy.md
+++ b/_posts/2020-F/2020-10-12-M104-Sombrero-Galaxy.md
@@ -2,7 +2,7 @@
 layout: post
 author: Bhuvan S V
 tags: Messier_Series Skywatching Sombrero_Galaxy
-category: "Uncategorized"
+category: Uncategorized
 type: Blog
 image: https://i.imgur.com/7NC6oYuh.jpg
 ---

--- a/_posts/2020-F/2020-11-09-Messier-44.md
+++ b/_posts/2020-F/2020-11-09-Messier-44.md
@@ -2,39 +2,40 @@
 layout: post
 author: Abdul Jawad Khan
 tags: Star_Cluster Observations Messier-Series NGC-2632
-category: "Uncategorized"
+category: Uncategorized
 type: Article
 image: https://i.imgur.com/jthbW69.png
 ---
-
+\
 Messier 44, or NGC 2632 is more commonly known as Praesepe or the Beehive Cluster. It is an open star cluster in the constellation Cancer, and is one of the nearest open clusters to Earth. An open star cluster is basically just a group of stars formed from the same giant molecular cloud, and thus have roughly the same age. M44 is a cluster of more than 1000 stars . Messier 44 has experienced mass segregation, a process often seen in star clusters and other gravitationally bound systems (e.g. galaxy clusters), by which heavier objects move toward the center, while lighter ones move away from the center. The bright, massive stars of M44 are now concentrated in the central region of the cluster while the fainter, less massive members are found in the halo.
 
-![Path](https://i.imgur.com/FRGG6LX.jpg)
-
+![Beehive Cluster](https://i.imgur.com/FRGG6LX.jpg)
+\
 *Beehive Cluster. Atlas Image obtained as part of the Two Micron All Sky Survey (2MASS)*
 
 M44 has an apparent magnitude of 3.7, and can easily be seen without binoculars. It appears as a blurry patch of light to the naked eye. However, the cluster is best seen with binoculars and small telescopes. The brightest stars in M44 have a visual magnitude of 6 to 6.5 and appear blue-white in color.
 
-## History:
+## History
 
-![Path](https://i.imgur.com/tF15HHk.jpg)
-
+![Wilhelm Schur's map](https://i.imgur.com/tF15HHk.jpg)
+\
 *Wilhelm Schur’s map of the Beehive Cluster in 1894*
 
 Messier 44 is a prominent deep sky object and has been known since ancient times. Classical astronomer Ptolemy described it as “nebulous mass in the breast of Cancer”, and it was among the first objects that Galileo studied with his telescope, even being able to resolve about 40 stars. Charles Messier added it to his famous catalog in 1769 after precisely measuring its position in the sky. Along with the Orion Nebula and the Pleiades cluster, Messier’s inclusion of the Beehive has been noted as curious, as most of Messier’s objects were much fainter and more easily confused with comets.
 
-## Composition:
+### Composition
 
 Altogether, the cluster contains at least 1000 gravitationally bound stars, for a total mass of about 500–600 Solar masses. A recent survey counts 1010 high-probability members, of which 68% are M dwarfs, 30% are Sun-like stars. Also present are five giant stars and eleven white dwarfs. Due to mass segregation, the brighter and more massive stars are closer to the core of the cluster while the smaller ones are towards the periphery.
 
 M44 is estimated to be about 600 million years old, and has been measured to be at an estimated distance of 182 parsecs.
 
-## Special Characteristics:
+## Special Characteristics
 
 In 2012, scientists discovered two planets orbiting two separate stars in the Beehive Cluster. These were the first planets discovered orbiting Sun-like stars in a star cluster. The planets, designated Pr0201b and Pr0211b, are hot Jupiters, extra-solar gas giants with characteristics similar to Jupiter and high surface temperatures because they have a much closer orbit to their parent stars. These planets are also known as roaster planets, epistellar jovians or pegasids.
 
-![Path](https://i.imgur.com/cW3BxxB.jpg)
+![Praesepe, Asellus Australis and Asellus Borealis](https://i.imgur.com/cW3BxxB.jpg)
 \
-*Praesepe, Asellus Australis and Asellus Borealis. Image: Wikisky*
+*Praesepe, Asellus Australis and Asellus Borealis.*
+*Image: Wikisky*
 
 M44 also occupies a special place in Greek and Roman mythology. Greek and Roman observers saw the cluster as a manger from which two donkeys are eating. The donkeys, represented by the nearby stars Asellus Borealis and Asellus Australis (Gamma and Delta Cancri), were the mythical animals on which the god Dionysus and his companion Silenus rode into battle against the Titans. In the myth, the Titans were frightened by the donkeys’ braying, which helped the gods win the battle. The donkeys were placed in the sky as a reward, along with the Manger, or Phatne in Greek.

--- a/_posts/2020-F/2020-12-02-Eagle-Nebula.md
+++ b/_posts/2020-F/2020-12-02-Eagle-Nebula.md
@@ -2,19 +2,19 @@
 layout: post
 author: Afraj Shaikh
 tags: Observations Nebula Pillars_of_Creation Messier-Series
-category: "Uncategorized"
+category: Uncategorized
 type: Article
 image: https://i.imgur.com/DhER9lk.png
 ---
- SEDS Celestia presents to you this amazing article about one of the most beautiful nebula present in this universe, Eagle Nebula. This articles talks in depth about interesting facts, science and history of this nebula including “The Pillars of Creation”. Dive right in to learn all about it .
-
-![Path](https://i.imgur.com/DhER9lk.png)
 \
-*Three-color composite mosaic image of the Eagle Nebula, with north at top. Credit: ESO*
+SEDS Celestia presents to you this amazing article about one of the most beautiful nebula present in this universe, Eagle Nebula. This articles talks in depth about interesting facts, science and history of this nebula including “The Pillars of Creation”. Dive right in to learn all about it .
 
+![Eagle Nebula](https://i.imgur.com/DhER9lk.png)
+\
+*Three-color composite mosaic image of the Eagle Nebula, with north at top.*
+*Credit: ESO*
 
 Nebulas are one of the most fascinating astronomical objects and have been a keen interest of astronomers for centuries. One of the most popular among them is Eagle Nebula. Eagle Nebula, also known as the Star Queen nebula is located in Serpens constellation at Serpens Cauda (the tail of the constellation). This nebula has been given sixteenth place in the Messier catalogue and has been blowing astronomers’ mind with its stellar beauty.
-
 
 ## History
 
@@ -24,7 +24,7 @@ Later, further studies revealed that there is a large area of glowing hydrogen w
 
 ## Pillars of Creation
 
-![Path](https://i.imgur.com/484XnUc.png)
+![Pillars of Creation](https://i.imgur.com/484XnUc.png)
 \
 *“The Pillars of Creation” – NASA, ESA and The Hubble Heritage Team*
 
@@ -36,18 +36,17 @@ In recent years, few observations have made astronomers question the existence o
 
 ![Stellar spire in the Eagle Nebula](https://i.imgur.com/RVikbhN.png)
 \
-[Stellar Spire in the Eagle Nebula, Image: NASA, ESA and Hubble Heritage Team]()
-
+*Stellar Spire in the Eagle Nebula, Image: NASA, ESA and Hubble Heritage Team*
 
 Stellar Spire is another active region of star formation located to the left of Pillars of Creation. It is a large tower of gas and is approximately 90 trillion kilometers in length. The ultraviolet light coming out of the young stars inside the spire have eroded it and is responsible for illuminating the rough surface of the spire.
 
-#### Composition
+## Composition
 
 The Eagle Nebula occupies an area of 70 by 55 light years in size (30 arc minutes) while its open star cluster has radius of about 15 light years (7 arc minutes in diameter). The brightest star in the Eagle Nebula is HD 168076. It is a binary star system which consist of O3.5V and O7.5V stars. This binary star system has an apparent magnitude of 8.24 and can be observed with good binoculars. This star has mass roughly 80 solar masses and luminosity of up to 1 million times of that of the Sun.
 
 The young open star cluster associated with Eagle Nebula; NGC 6611 was formed 5.5 million years ago. It is a type-c cluster which means it is very loose and irregular. The ultraviolet glow of hot, blue stars of this cluster is mainly responsible for the brightness of Eagle Nebula. Scientists suspect that the nebula has various such type of star-forming clusters within it.
 
-#### Location
+## Location
 
 M16 is about 7000 light years away from earth and resides in Serpens constellation. Its co-ordinates in Equatorial Co-ordinate system is given by RA  18h 18m 48s Dec -13° 49’ 0’’. M16 has an apparent magnitude of 6. There are different stars and constellations near M16 which also helps in providing its relative position with respect to them.
 
@@ -55,23 +54,23 @@ For example, it is located 2.5 degrees in west of Gamma Scuti and a few degrees 
 
 ***Here comes the end of this article, I guess I have covered a lot of interesting facts about Eagle Nebula. So, let me summarize some of the facts: –***
 
-**Eagle Nebula – Messier 16**
-\
-Constellation: Serpens (at Serpens Cauda)
-\
-Coordinates: Right Ascension 18h18m48s, Declination -13°49′0’’
-\
-Distance: 7,000 light years
-\
-Visual magnitude: +6
+### Eagle Nebula – Messier 16
 
-Absolute magnitude: -8.21
+Constellation: **Serpens (at Serpens Cauda)**
 \
-Apparent dimensions: 30 arc minutes\
-Radius: 70×55 light years
+Coordinates: **Right Ascension 18h18m48s, Declination -13°49′0’’**
 \
-Estimated age: 5.5 million years
+Distance: **7,000 light years**
 \
-Designations: Eagle Nebula, Star Queen Nebula, Messier 16 (M16), NGC 6611, IC 4703, Gum 83, Sharpless 49, RCW 165
+Visual magnitude: **+6**
+
+Absolute magnitude: **-8.21**
+\
+Apparent dimensions: **30 arc minutes**\
+Radius: **70×55 light years**
+\
+Estimated age: **5.5 million years**
+\
+Designations: **Eagle Nebula, Star Queen Nebula, Messier 16 (M16), NGC 6611, IC 4703, Gum 83, Sharpless 49, RCW 165**
 
 I hope this article would have given a brief insight about the Eagle Nebula. Well, Eagle Nebula is just one of the many fascinating messier objects and there’re lots of them to come in this messier series so do keep a track of them!!

--- a/_posts/2021/2021-01-25-Messier-97-Owl-Nebula.md
+++ b/_posts/2021/2021-01-25-Messier-97-Owl-Nebula.md
@@ -7,7 +7,7 @@ category: "Uncategorized"
 type: Article
 image: https://i.imgur.com/prODvcm.jpg
 ---
-\
+
 The Owl Nebula, also known as Messier 97 (M97), is a planetary nebula located in Ursa Major. The nebula lies at an approximate distance of 2,030 light years from Earth. It is known for its distinctive shape, resembling a pair of owl-like eyes, that can be seen in larger telescopes. Learn more about it in this interesting article by our club member Gayatri.
 
 ## Introduction
@@ -25,8 +25,7 @@ This nebula was discovered by the French astronomer Pierre Méchain on February 
 
 ![The Owl Nebula - Cosmic Pursuits](http://cosmicpursuits.com/wp-content/uploads/2015/05/m97-owl-nebula.jpg)
 \
-[Original drawing of the Owl Nebula]()
-{: .link-desc}
+*Original drawing of the Owl Nebula*
 
 ## Composition
 

--- a/_posts/2021/2021-02-08-Messier-45-Pleiades.md
+++ b/_posts/2021/2021-02-08-Messier-45-Pleiades.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Messier 45: Pleiades"
 author: Ashutosh Gupta
-tags: Messier-45  Pleiades  Star_Cluster
+tags: Messier-Series Pleiades Star_Cluster
 category: Uncategorized
 type: Article
 image: https://i.imgur.com/GIWxodV.png

--- a/_posts/2021/2021-02-08-Messier-45-Pleiades.md
+++ b/_posts/2021/2021-02-08-Messier-45-Pleiades.md
@@ -2,8 +2,8 @@
 layout: post
 title:  "Messier 45: Pleiades"
 author: Ashutosh Gupta
-tags: Messier-Series Pleiades Star_Cluster
-category: "Uncategorized"
+tags: Messier-45  Pleiades  Star_Cluster
+category: Uncategorized
 type: Article
 image: https://i.imgur.com/GIWxodV.png
 ---
@@ -23,7 +23,6 @@ The first astronomer to view the Pleiades through a telescope was Galileo Galile
 ![Galileo’s drawings of the Pleiades](https://i.imgur.com/fcOb3OS.png)
 \
 *Galileo’s drawings of the Pleiades*
-{: .link-desc}
 
 In 1767, John Michell determined that the likelihood of a chance alignment of so many bright stars was just 1 in 500,000, so it surmised that the Pleiades and many other star clusters must be physically related. When studies were first made of the stars’ proper motions, it was found that they are all moving in the same direction across the sky, at the same rate, further demonstrating that they were related.
 
@@ -37,12 +36,12 @@ The cluster contains many brown dwarfs, which are objects with less than about 8
 
 ## How to Locate
 
-![Path](https://i.imgur.com/vqBv9Kg.png)
+![Location](https://i.imgur.com/vqBv9Kg.png)
 
 The Pleiades cluster is straightforward to find. It is located about 14 degrees northwest of Aldebaran, the brightest star in Taurus and 14th brightest star in the night sky. When the cluster is high in the sky, it can be located by following the line formed by the three bright stars that form Orion’s Belt: Alnilam, Alnitak and Mintaka. M45 lies to the northwest of the celestial Hunter.
 
 ## Special Characteristics
 
-![Path](https://i.imgur.com/THHVokF.png)
+![Special Characteristics](https://i.imgur.com/THHVokF.png)
 
 The nine brightest stars of the Pleiades are named for the Seven Sisters of Greek mythology: Sterope, Merope, Electra, Maia, Taygeta, Celaeno, and Alcyone, along with their parents Atlas and Pleione. By pointing Kepler at the Pleiades, researchers confirmed that six of the Seven Sisters — Alcyone, Atlas, Electra, Merope, Taygete and Pleione — are slowly pulsating type B stars, which change in brightness over the course of one day. The seventh star, named Maia, has a brightness that fluctuates over a more extended period of 10 days.

--- a/_posts/2021/2021-03-08-Astrophotography-for-Beginners.md
+++ b/_posts/2021/2021-03-08-Astrophotography-for-Beginners.md
@@ -6,7 +6,6 @@ category: "Uncategorized"
 type: Article
 image: https://cdn.pixabay.com/photo/2017/08/30/01/05/milky-way-2695569_1280.jpg
 ---
-
 \
 The night sky can be considered as one of the most magnificent spectacles that we can experience every night. The twinkling stars, the bright moon and the cold yet exciting breeze all make the experience of stargazing literally out of the world. However nowadays as many of us live in populated cities where it is almost impossible to escape the light pollution it is very difficult to view the night sky at its complete beauty. In such cases devices like the DSLRs or even smart phones can come to our rescue.
 

--- a/_posts/2021/2021-07-12-Space-Tethers.md
+++ b/_posts/2021/2021-07-12-Space-Tethers.md
@@ -1,0 +1,40 @@
+---
+layout: post
+author: Suchetan R S
+tags: Science Space_tech SpaceRobotics Technology-in-space Author:Suchetan-R-S 
+category: Science Space_News SpaceRobotics
+type: Article
+image: https://i.imgur.com/i21mv89h.png
+---
+
+We as humans are pushing our limits in space exploration and are crossing the boundaries we never thought we would. But every time we blast off that 1.5 kilo-ton machine into space we incur huge costs. This limits our capabilities since the world runs on economic gain after all.
+
+Due to this huge requirement of energy, every rocket with the payload we try to put into orbit is nearly 90% fuel. The actual payload is just 4% of the total mass. [1]
+
+Over the years, scientists have found many ingenious ways to overcome this barrier. One of the most ingenious solutions is the use of skyhooks or tethers!
+In layman’s terms, it is a sort of a rotating hook that is orbiting our planet. It is one of the most amazing applications of putting orbital energy to use.
+
+![Momentum exchange tether in operation](https://i.imgur.com/0TJPTVil.png)\
+*Figure 1: Momentum exchange tether in operation.* [2]
+
+Look at the illustration to get an intuitive idea about what tethers look like and how they function. In traditional rocket launches, the rocket is blasted off in order to reach the escape velocity of 11.2 km/s and escape the earth’s orbit. With a tether in place, things work a little differently. The bottom tip of the tether would be racing at about 4,000 km/hr through the uppermost layers of the atmosphere. We would have several opportunities to catch the bottom end of the tether. When the bottom end of the tether reaches the top most point, the task at hand would be to screw off from the tether and use the momentum to swing off and position ourselves into a higher orbit. Tethers can effectively reduce costs to position satellites into LEO (Low-earth orbit) by more than 50%.
+
+![Tether tip approaching payload before attachment](https://i.imgur.com/FRzmMFkl.png)\
+
+Figure 2: Tether tip approaching payload before attachment. [2]
+
+A little more information about how a momentum-exchange tether (MXT) works: In simple words, the working is purely based on conservation of angular momentum. For example, as the tether passes through the perigee it’s COM would be moving at 8.9km/s with the tip velocity being 1.2 km/s. the orbital velocity of the payload must be ensured to be 7.7km/s. Since the motion of the tip of the tether and the spacecraft are opposite in nature, it ensures there is zero relative velocity between the center of mass of MXT and the payload just before the attachment which will lead to a successful catch of the payload. Once this is done, the MXT loses energy and assumes a lower orbit while the payload gains this energy. The payload gains the velocity equal to twice the velocity of its tip which in the illustrated case would be 2.4km/s which is the typical ΔV required for a GTO (Geosynchronous-transfer orbit) through perigee burn (Hoffman Transfer orbit).[3] This gain is almost instantaneous and much faster than the conventional chemical propulsion. The figure illustrates this diagrammatically.
+
+This innovation, once mastered has countless applications. For example, an electrodynamic tether could be constructed. This 20 km long tether would be made of a conducting material which could produce 15-30 kW[4] of power using the earth’s magnetic field (An effective application of Lorentz force). This could be used to power on-board experiments of many satellites.
+
+Tethers are not all easy to build, they have limitations as well. Objects in the low-earth orbit are subjected to noticeable erosion from atomic oxygen due to their high orbital speed with which the molecules strike. The space is filled with micrometeorites and space junk. Although these are being tracked on radar and have predictable orbits, a large piece could easily cut most tethers. Apart from these, there is radiation, including UV radiation which tend to degrade tethers and reduce its life span.
+
+There have been many successful space tether missions in the past including the SEDS-2 and the PMG missions [5]. With technology advancing at a pace faster than ever before, there is nothing stopping us from building a successful MXT tether to lift off into space.
+
+#### References
+
+1. <http://web.mit.edu/16.00/www/aec/rocket.html>
+2. <https://web.wpi.edu/Pubs/E-project/Available/E-project-031207-235520/unrestricted/Space_Tethers_IQP.pdf>
+3. <https://en.wikipedia.org/wiki/Hohmann_transfer_orbit#:~:text=Therefore%20the%20%CE%94v%20for%20the,7.73%20%3D%203.20%20km%2Fs>
+4. <https://link.springer.com/chapter/10.1007/978-94-011-2048-7_32#:~:text=For%20a%2020%20km%20tether,30%20kW%20can%20be%20generated>.
+5. <https://en.wikipedia.org/wiki/Space_tether_missions>


### PR DESCRIPTION
- Categories 
Cleaned categories of the blogs of double quotes

- Tags format
Changed format from _["tag1", "tag2", "tag2"]_ to _tag1 tag2 tag3_

- Fixed the trailing characters of existing blogs in titles(acc to kramdown rules)

- Fixed the titles of blogpost files to the right format

- Imported Space Tethers Blog and added author info

- Spelling error correction during migration